### PR TITLE
#41 create album spotify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+* `/api/spotify-album` endpoint.
+
 ## 1.8.0 - 2022-01-30
 
 ### Added

--- a/src/models/AlbumModel.ts
+++ b/src/models/AlbumModel.ts
@@ -66,7 +66,7 @@ class AlbumModel {
   }
 
   /**
-   * Create a new album in the database.
+   * Creates a new album in the database.
    * @param spotifyAlbumId Spotify ID of the album
    * @param posterId       member ID of the album poster
    * @return the created album document
@@ -74,20 +74,20 @@ class AlbumModel {
   public static async create(spotifyAlbumId: string, posterId: string): Promise<any> {
     try {
       // Fetch album data
-      const spotifyAlbumData: any = await AlbumModel.fetchSpotifyAlbumData(spotifyAlbumId);
+      const albumData: any = await AlbumModel.fetchSpotifyAlbumData(spotifyAlbumId);
 
       // Define post data
       const postData: any = {
         posterId,
         topDiskNumber: null,
         topTrackNumber: null,
-        tracks: spotifyAlbumData.tracks.map((track: any): any => { return { ...track, pickerIds: [] }; })
+        tracks: albumData.tracks.map((track: any): any => { return { ...track, pickerIds: [] }; })
       };
 
-      // Create album document
+      // Define album document
       const albumDoc: any = {
         id: uuidv4(),
-        ...spotifyAlbumData,
+        ...albumData,
         ...postData
       };
 

--- a/src/models/AlbumModel.ts
+++ b/src/models/AlbumModel.ts
@@ -99,16 +99,6 @@ class AlbumModel {
     }
   }
 
-    // Create the album document in the database
-    this.model.create(albumDoc, (err: NativeError, album: Document) => {
-      if (err) {
-        res.json("Failed to create album");
-      } else {
-        res.json(album);
-      }
-    });
-  }
-
   /**
    * Update an existing album.
    */

--- a/src/routes/album_routes.ts
+++ b/src/routes/album_routes.ts
@@ -21,8 +21,8 @@ router.post('/api/album', (req: Request, res: Response): void => {
   }
 
   AlbumModel.create(req.body.spotifyId, req.body.posterId)
-    .then((newAlbum: any) => {
-      res.json(newAlbum);
+    .then((createdAlbum: any) => {
+      res.json(createdAlbum);
     })
     .catch((err: any): void => {
       res.status(err.response.status || 500).send({

--- a/src/routes/album_routes.ts
+++ b/src/routes/album_routes.ts
@@ -7,8 +7,31 @@ import { AlbumModel } from '../models/AlbumModel';
 const router: Router = Router();
 
 // Create a new album
-router.post('/api/album', (req: Request, res: Response) => {
-  return AlbumModel.createAlbum(req, res);
+router.post('/api/album', (req: Request, res: Response): void => {
+  if (!('spotifyId' in req.body)) {
+    res.status(400);
+    res.send('Bad request. Missing arg: spotifyId');
+    return;
+  }
+
+  if (!('posterId' in req.body)) {
+    res.status(400);
+    res.send('Bad request. Missing arg: posterId');
+    return;
+  }
+
+  AlbumModel.create(req.body.spotifyId, req.body.posterId)
+    .then((newAlbum: any) => {
+      res.json(newAlbum);
+    })
+    .catch((err: any): void => {
+      res.status(err.response.status || 500).send({
+        error: {
+          status: err.response.status || 500,
+          message: err.response.statusText || 'Internal server error',
+        }
+      });
+    });
 });
 
 // Update an existing album

--- a/src/routes/spotify_routes.ts
+++ b/src/routes/spotify_routes.ts
@@ -224,4 +224,4 @@ router.get('/api/spotify-audio-features', async (req: Request, res: Response) =>
   }
 });
 
-export default router;
+export { router, fetchSpotifyAlbumSearch, fetchSpotifyArtist, fetchSpotifyAlbumTracks, fetchSpotifyAudioFeatures };

--- a/src/routes/spotify_routes.ts
+++ b/src/routes/spotify_routes.ts
@@ -85,14 +85,14 @@ async function fetchSpotifyAlbumSearch(searchQuery: string): Promise<any> {
 }
 
 /**
- * Fetches an artist from Spotify.
- * @param spotifyArtistId the Spotify ID of the artist
- * @return a promise for a Spotify artist
+ * Fetches an album from Spotify.
+ * @param spotifyAlbumId the Spotify ID of the album
+ * @return a promise for a Spotify album
  */
-async function fetchSpotifyArtist(spotifyArtistId: string): Promise<any> {
+async function fetchSpotifyAlbum(spotifyAlbumId: string): Promise<any> {
   const requestFun = async (): Promise<any> => {
-    const artistResult: AxiosResponse = await axios({
-      url: `https://api.spotify.com/v1/artists/${spotifyArtistId}`,
+    const albumResult: AxiosResponse = await axios({
+      url: `https://api.spotify.com/v1/albums/${spotifyAlbumId}`,
       headers: {
         'Accept': 'application/json',
         'Content-Type': 'application/x-www-form-urlencoded'
@@ -102,7 +102,7 @@ async function fetchSpotifyArtist(spotifyArtistId: string): Promise<any> {
       }
     });
 
-    return Promise.resolve(artistResult);
+    return Promise.resolve(albumResult);
   };
 
   return await makeSpotifyRequest(requestFun);
@@ -127,6 +127,30 @@ async function fetchSpotifyAlbumTracks(spotifyAlbumId: string): Promise<any> {
     });
 
     return Promise.resolve(tracksResult);
+  };
+
+  return await makeSpotifyRequest(requestFun);
+}
+
+/**
+ * Fetches an artist from Spotify.
+ * @param spotifyArtistId the Spotify ID of the artist
+ * @return a promise for a Spotify artist
+ */
+async function fetchSpotifyArtist(spotifyArtistId: string): Promise<any> {
+  const requestFun = async (): Promise<any> => {
+    const artistResult: AxiosResponse = await axios({
+      url: `https://api.spotify.com/v1/artists/${spotifyArtistId}`,
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      params: {
+        access_token: store.get('spotifyAccessToken')
+      }
+    });
+
+    return Promise.resolve(artistResult);
   };
 
   return await makeSpotifyRequest(requestFun);
@@ -176,16 +200,16 @@ router.get('/api/album-search', async (req: Request, res: Response): Promise<voi
   }
 });
 
-router.get('/api/artist', async (req: Request, res: Response): Promise<void> => {
-  if (!('id' in req.query)) {
+router.get('/api/album', async (req: Request, res: Response): Promise<void> => {
+  if (!('spotifyAlbumId' in req.query)) {
     res.status(400);
-    res.send('Missing required args: id');
+    res.send('Missing required args: spotifyAlbumId');
     return;
   }
 
   try {
-    const artistResult: any = await fetchSpotifyArtist(String(req.query.id));
-    res.json(artistResult.data);
+    const albumResult: any = await fetchSpotifyAlbum(String(req.query.spotifyAlbumId));
+    res.json(albumResult.data);
   } catch(err) {
     res.status(err.response.status);
     res.send(err.response.statusText);
@@ -208,6 +232,22 @@ router.get('/api/spotify-album-tracks', async (req: Request, res: Response): Pro
   }
 });
 
+router.get('/api/artist', async (req: Request, res: Response): Promise<void> => {
+  if (!('id' in req.query)) {
+    res.status(400);
+    res.send('Missing required args: id');
+    return;
+  }
+
+  try {
+    const artistResult: any = await fetchSpotifyArtist(String(req.query.id));
+    res.json(artistResult.data);
+  } catch(err) {
+    res.status(err.response.status);
+    res.send(err.response.statusText);
+  }
+});
+
 router.get('/api/spotify-audio-features', async (req: Request, res: Response) => {
   if (!('spotifyTrackId' in req.query)) {
     res.status(400);
@@ -224,4 +264,4 @@ router.get('/api/spotify-audio-features', async (req: Request, res: Response) =>
   }
 });
 
-export { router, fetchSpotifyAlbumSearch, fetchSpotifyArtist, fetchSpotifyAlbumTracks, fetchSpotifyAudioFeatures };
+export { router, fetchSpotifyAlbum, fetchSpotifyAlbumSearch, fetchSpotifyAlbumTracks, fetchSpotifyArtist, fetchSpotifyAudioFeatures };

--- a/src/routes/spotify_routes.ts
+++ b/src/routes/spotify_routes.ts
@@ -200,7 +200,7 @@ router.get('/api/album-search', async (req: Request, res: Response): Promise<voi
   }
 });
 
-router.get('/api/album', async (req: Request, res: Response): Promise<void> => {
+router.get('/api/spotify-album', async (req: Request, res: Response): Promise<void> => {
   if (!('spotifyAlbumId' in req.query)) {
     res.status(400);
     res.send('Missing required args: spotifyAlbumId');

--- a/src/routes/spotify_routes.ts
+++ b/src/routes/spotify_routes.ts
@@ -3,7 +3,7 @@ import axios, { AxiosRequestConfig, AxiosPromise, AxiosResponse } from 'axios';
 import { Request, Response, Router } from 'express';
 import store from 'store2';
 
-const router: Router = Router();
+// Helper functions
 
 /**
  * Update the server's Spotify API access token.
@@ -29,56 +29,44 @@ async function updateAccessToken(): Promise<void> {
 }
 
 /**
- * Make a request to the Spotify API. If the initial request was unauthorized, try updating the access  token and retry
+ * Make a request to the Spotify API. If the initial request was unauthorized, try updating the access token and retry
  * the request.
  * @param reqFun request function to perform
- * @param res    result object of the route which called this function
  */
-async function makeSpotifyRequest(reqFun: any, res: Response): Promise<void> {
+async function makeSpotifyRequest(reqFun: any): Promise<any> {
   try {
-    await reqFun();
+    return Promise.resolve(await reqFun());
   } catch(err) {
     // Only retry the request if there was an authorization error
     if (err.response.status !== 401) {
-      res.status(err.response.status);
-      res.send(err.response.statusText);
-      return;
+      throw err;
     }
 
     // Try updating the access token
     try {
       await updateAccessToken();
     } catch(tokenErr) {
-      res.status(tokenErr.response.status);
-      res.send(tokenErr.response.statusText);
-      return;
+      throw err;
     }
 
     // Retry the request
     try {
-      await reqFun();
+      return Promise.resolve(await reqFun());
     } catch(retryErr) {
-      res.status(retryErr.response.status);
-      res.send(retryErr.response.statusText);
+      throw err;
     }
   }
 }
 
-// TODO: Make the search endpoint more generic. Let the client define the item type.
-
 /**
- * Endpoint for making a Spotify API album search request.
+ * Fetches album search results from Spotify.
+ * @param searchQuery the term to search for
+ * @return a promise for a Spotify search result
  */
-router.get('/api/album-search', async (req: Request, res: Response): Promise<void> => {
-  if (!('q' in req.query)) {
-    res.status(400);
-    res.send('Missing required args: q');
-    return;
-  }
+async function fetchSpotifyAlbumSearch(searchQuery: string): Promise<any> {
+  const encodedQuery: string = encodeURIComponent(searchQuery.toString());
 
-  const encodedQuery: string = encodeURIComponent(req.query.q.toString());
-
-  const requestFun = async (): Promise<void> => {
+  const requestFun = async (): Promise<any> => {
     const searchResult: any = await axios({
       url: `https://api.spotify.com/v1/search?q=${encodedQuery}&type=album&limit=10`,
       headers: {
@@ -90,15 +78,104 @@ router.get('/api/album-search', async (req: Request, res: Response): Promise<voi
       }
     });
 
-    res.json(searchResult.data.albums);
+    return Promise.resolve(searchResult);
   };
 
-  makeSpotifyRequest(requestFun, res);
-});
+  return await makeSpotifyRequest(requestFun);
+}
 
 /**
- * Endpoint for making a Spotify API artist request.
+ * Fetches an artist from Spotify.
+ * @param spotifyArtistId the Spotify ID of the artist
+ * @return a promise for a Spotify artist
  */
+async function fetchSpotifyArtist(spotifyArtistId: string): Promise<any> {
+  const requestFun = async (): Promise<any> => {
+    const artistResult: AxiosResponse = await axios({
+      url: `https://api.spotify.com/v1/artists/${spotifyArtistId}`,
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      params: {
+        access_token: store.get('spotifyAccessToken')
+      }
+    });
+
+    return Promise.resolve(artistResult);
+  };
+
+  return await makeSpotifyRequest(requestFun);
+}
+
+/**
+ * Fetches an album's tracks from Spotify.
+ * @param spotifyAlbumId the Spotify ID of the album
+ * @return a promise for a list of Spotify tracks
+ */
+async function fetchSpotifyAlbumTracks(spotifyAlbumId: string): Promise<any> {
+  const requestFun = async (): Promise<any> => {
+    const tracksResult: AxiosResponse = await axios({
+      url: `https://api.spotify.com/v1/albums/${spotifyAlbumId}/tracks`,
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      params: {
+        access_token: store.get('spotifyAccessToken')
+      }
+    });
+
+    return Promise.resolve(tracksResult);
+  };
+
+  return await makeSpotifyRequest(requestFun);
+}
+
+/**
+ * Fetches a track's audio features from Spotify.
+ * @param spotifyTrackId the Spotify ID of the artist
+ * @return a promise for a track's audio features
+ */
+async function fetchSpotifyAudioFeatures(spotifyTrackId: string): Promise<any> {
+  const requestFun = async (): Promise<any> => {
+    const audioFeaturesResult: AxiosResponse = await axios({
+      url: `https://api.spotify.com/v1/audio-features/${spotifyTrackId}`,
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      params: {
+        access_token: store.get('spotifyAccessToken')
+      }
+    });
+
+    return Promise.resolve(audioFeaturesResult);
+  };
+
+  return await makeSpotifyRequest(requestFun);
+}
+
+// Endpoints
+
+const router: Router = Router();
+
+router.get('/api/album-search', async (req: Request, res: Response): Promise<void> => {
+  if (!('q' in req.query)) {
+    res.status(400);
+    res.send('Missing required args: q');
+    return;
+  }
+
+  try {
+    const searchResult: any = await fetchSpotifyAlbumSearch(String(req.query.q));
+    res.json(searchResult.data.albums);
+  } catch(err) {
+    res.status(err.response.status);
+    res.send(err.response.statusText);
+  }
+});
+
 router.get('/api/artist', async (req: Request, res: Response): Promise<void> => {
   if (!('id' in req.query)) {
     res.status(400);
@@ -106,27 +183,15 @@ router.get('/api/artist', async (req: Request, res: Response): Promise<void> => 
     return;
   }
 
-  const requestFun = async (): Promise<void> => {
-    const artistResult: AxiosResponse = await axios({
-      url: `https://api.spotify.com/v1/artists/${req.query.id}`,
-      headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/x-www-form-urlencoded'
-      },
-      params: {
-        access_token: store.get('spotifyAccessToken')
-      }
-    });
-
-   res.json(artistResult.data);
- };
-
- makeSpotifyRequest(requestFun, res);
+  try {
+    const artistResult: any = await fetchSpotifyArtist(String(req.query.id));
+    res.json(artistResult.data);
+  } catch(err) {
+    res.status(err.response.status);
+    res.send(err.response.statusText);
+  }
 });
 
-/**
- * Endpoint for making a Spotify API album tracks request.
- */
 router.get('/api/spotify-album-tracks', async (req: Request, res: Response): Promise<void> => {
   if (!('spotifyAlbumId' in req.query)) {
     res.status(400);
@@ -134,27 +199,15 @@ router.get('/api/spotify-album-tracks', async (req: Request, res: Response): Pro
     return;
   }
 
-  const requestFun = async (): Promise<void> => {
-    const tracksResult: AxiosResponse = await axios({
-      url: `https://api.spotify.com/v1/albums/${req.query.spotifyAlbumId}/tracks`,
-      headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/x-www-form-urlencoded'
-      },
-      params: {
-        access_token: store.get('spotifyAccessToken')
-      }
-    });
-
+  try {
+    const tracksResult: any = await fetchSpotifyAlbumTracks(String(req.query.spotifyAlbumId));
     res.json(tracksResult.data);
-  };
-
-  makeSpotifyRequest(requestFun, res);
+  } catch(err) {
+    res.status(err.response.status);
+    res.send(err.response.statusText);
+  }
 });
 
-/**
- * Endpoint for making a Spotify API audio features request.
- */
 router.get('/api/spotify-audio-features', async (req: Request, res: Response) => {
   if (!('spotifyTrackId' in req.query)) {
     res.status(400);
@@ -162,22 +215,13 @@ router.get('/api/spotify-audio-features', async (req: Request, res: Response) =>
     return;
   }
 
-  const requestFun = async (): Promise<void> => {
-    const audioFeaturesResult: AxiosResponse = await axios({
-      url: `https://api.spotify.com/v1/audio-features/${req.query.spotifyTrackId}`,
-      headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/x-www-form-urlencoded'
-      },
-      params: {
-        access_token: store.get('spotifyAccessToken')
-      }
-    });
-
+  try {
+    const audioFeaturesResult: any = await fetchSpotifyAudioFeatures(String(req.query.spotifyTrackId));
     res.json(audioFeaturesResult.data);
-  };
-
-  makeSpotifyRequest(requestFun, res);
+  } catch(err) {
+    res.status(err.response.status);
+    res.send(err.response.statusText);
+  }
 });
 
 export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -25,7 +25,7 @@ import memberRoutes from './routes/member_routes';
 import memberInsightsRoutes from './routes/member_insights_routes';
 import roundRoutes from './routes/round_routes';
 import authRoutes from './routes/auth_routes';
-import spotifyRoutes from './routes/spotify_routes';
+import { router as spotifyRoutes } from './routes/spotify_routes';
 
 // Connect to database
 Database.connect();


### PR DESCRIPTION
Album creation is now almost entirely handled by the server. As a by-product, the `/api/spotify-album` endpoint is now available.  

Closes #41 