### PR TITLE
#43 req res album delete

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "music-club",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Music Club backend service",
   "main": "dist/server.js",
   "scripts": {

--- a/src/models/AlbumModel.ts
+++ b/src/models/AlbumModel.ts
@@ -121,16 +121,20 @@ class AlbumModel {
     });
   }
 
-  public static deleteAlbum(req: any, res: Response): any {
-    const query: any = this.model.findOneAndDelete(req.query);
+  /**
+   * Deletes an album from the database.
+   * @param id ID of the album
+   * @return the deleted album
+   */
+  public static async delete(id: string): Promise<any> {
+    try {
+      const query: any = this.model.findOneAndDelete({ id });
+      const deletedAlbum: any = query.exec();
 
-    query.exec((err: NativeError, album: Document) => {
-      if (err) {
-        res.json("Failed to delete album");
-      } else {
-        res.json(album);
-      }
-    });
+      return Promise.resolve(deletedAlbum);
+    } catch (err: any) {
+      throw err;
+    }
   }
 
   /**

--- a/src/routes/album_routes.ts
+++ b/src/routes/album_routes.ts
@@ -47,7 +47,18 @@ router.delete('/api/album', (req: Request, res: Response) => {
     return;
   }
 
-  return AlbumModel.deleteAlbum(req, res);
+  return AlbumModel.delete(String(req.query.id))
+    .then((deletedAlbum: any): void => {
+      res.json(deletedAlbum);
+    })
+    .catch((err: any): void => {
+      res.status(err.response.status || 500).send({
+        error: {
+          status: err.response.status || 500,
+          message: err.response.statusText || 'Internal server error',
+        }
+      });
+    });
 });
 
 // Get an album


### PR DESCRIPTION
Extracted `req` and `res` params from Album model deletion function so they stay in the endpoint handler.